### PR TITLE
fix error in Symfony 4

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,6 @@
 services:
+    _defaults: { public: true }
+
     richardhj.klarna_checkout.controller.push:
         class: Richardhj\IsotopeKlarnaCheckoutBundle\Controller\Push
 


### PR DESCRIPTION
This should fix
```
[2019-01-31 13:26:13] request.CRITICAL: Uncaught PHP Exception Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "The service "richardhj.klarna_checkout.hook_listener.find_surcharges_for_collection" was not found or is not public. See https://symfony.com/doc/current/service_container.html#public-versus-private-services" at /var/virtual/XXX/public/vendor/contao/core-bundle/src/Resources/contao/library/Contao/System.php line 226 {"exception":"[object] (Symfony\\Component\\DependencyInjection\\Exception\\ServiceNotFoundException(code: 0): The service \"richardhj.klarna_checkout.hook_listener.find_surcharges_for_collection\" was not found or is not public. See https://symfony.com/doc/current/service_container.html#public-versus-private-services at /var/virtual/XXX/public/vendor/contao/core-bundle/src/Resources/contao/library/Contao/System.php:226)"} []
```
(ignore the wrong commit message 😉)