### PR TITLE
Contao 4.13 support. Wrong Tax. Klarna Password Length.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=7.4",
     "ext-json": "*",
     "contao/core-bundle": "^4.9",
-    "doctrine/dbal": "^3.0",
+    "doctrine/dbal": "^2.0 || ^3.0",
     "isotope/isotope-core": "^2.6",
     "symfony/dependency-injection": "^4.4 || ^5.0",
     "symfony/http-client": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=7.4",
     "ext-json": "*",
     "contao/core-bundle": "^4.9",
-    "doctrine/dbal": "^2.0",
+    "doctrine/dbal": "^3.0",
     "isotope/isotope-core": "^2.6",
     "symfony/dependency-injection": "^4.4 || ^5.0",
     "symfony/http-client": "^4.4 || ^5.0",

--- a/src/Dto/ShippingOption.php
+++ b/src/Dto/ShippingOption.php
@@ -74,6 +74,6 @@ final class ShippingOption
         $rate = StringUtil::deserialize($includes->rate, true);
 
         $this->tax_rate = (int) round($rate['value'] * 100);
-        $this->tax_amount = (int) round($includes->calculateAmountIncludedInPrice($this->price) * 100);
+        $this->tax_amount = (int) round($includes->calculateAmountIncludedInPrice($this->price));
     }
 }

--- a/src/Dto/Surcharge.php
+++ b/src/Dto/Surcharge.php
@@ -34,7 +34,7 @@ final class Surcharge extends AbstractOrderLine
 
         if ($surcharge->hasTax()) {
             $this->total_tax_amount = (int) round(($surcharge->total_price - $surcharge->tax_free_total_price) * 100);
-            $this->tax_rate = (int) round(($this->total_tax_amount / $this->total_amount) * 1000);
+            $this->tax_rate = (int) round(($surcharge->total_price / $surcharge->tax_free_total_price - 1 ) * 10000);
         } else {
             $this->tax_rate = 0;
             $this->total_tax_amount = 0;

--- a/src/Resources/contao/dca/tl_iso_config.php
+++ b/src/Resources/contao/dca/tl_iso_config.php
@@ -49,7 +49,7 @@ $GLOBALS['TL_DCA']['tl_iso_config']['fields']['klarna_api_password'] = [
         'mandatory' => true,
         'tl_class' => 'w50',
     ],
-    'sql' => "varchar(64) NOT NULL default ''",
+    'sql' => "varchar(255) NOT NULL default ''",
 ];
 
 $GLOBALS['TL_DCA']['tl_iso_config']['fields']['klarna_api_test'] = [


### PR DESCRIPTION
- [Klarna Error “Bad value: total_tax_amount” and "tax_rate" #13](https://github.com/richardhj/isotope-klarna-checkout/issues/13)

- [ Installation auf Contao 4.13.25 LTS - doctrine/dbal Konflikt #12 ](https://github.com/richardhj/isotope-klarna-checkout/issues/12)

- handle Klarna Passwords longer than 64 characters. our password is around 180 chars